### PR TITLE
Added comma-dangle 'never' to .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "mocha": true
   },
   "rules": {
-    "semi": [2, "always"]
+    "semi": [2, "always"],
+    "comma-dangle": [2, "never"]
   }
 }

--- a/server/graphql/user.js
+++ b/server/graphql/user.js
@@ -1,7 +1,7 @@
 import {
 	GraphQLString,
 	GraphQLInt,
-	GraphQLObjectType,
+	GraphQLObjectType
 } from 'graphql';
 
 const User = new GraphQLObjectType({


### PR DESCRIPTION
Proposed addition to eslint config to give error on trailing commas.
For more info: http://eslint.org/docs/rules/comma-dangle

Example of code that will error:
```js
/*eslint comma-dangle: ["error", "never"]*/

var foo = {
    bar: "baz",
    qux: "quux",
};

var arr = [1,2,];

foo({
  bar: "baz",
  qux: "quux",
});
```